### PR TITLE
unity websocket 无法支持二进制格式发送, 因为unity传过来的是Uint8Array, 需要进行转换

### DIFF
--- a/Demo/Ranking/Assets/WX-WASM-SDK/wechat-default/weapp-adapter.js
+++ b/Demo/Ranking/Assets/WX-WASM-SDK/wechat-default/weapp-adapter.js
@@ -1522,6 +1522,10 @@ try{
             }, {
                 key: 'send',
                 value: function send(data) {
+                    if(data instanceof Uint8Array) {
+                        data = data.buffer;
+                    }
+
                     if (typeof data !== 'string' && !(data instanceof ArrayBuffer) && !((typeof data) === 'object')) {
                         throw new TypeError('Failed to send message: The data ' + data + ' is invalid');
                     }


### PR DESCRIPTION
传送byte[]的被当成文本发送