### PR TITLE
添加编译条件，解决程序在webGL以外的平台编译报错的问题

### DIFF
--- a/Design/InputAdaptation.md
+++ b/Design/InputAdaptation.md
@@ -6,6 +6,8 @@
 
 以UGUI的Input组件为例，需要给Input 绑定以下脚本：
 ```
+#if UNITY_WEBGL || UNITY_EDITOR
+
 using UnityEngine;
 using System.Collections;
 using WeChatWASM;
@@ -89,4 +91,7 @@ public class Inputs : MonoBehaviour, IPointerClickHandler, IPointerExitHandler
         }
     }
 }
+
+#endif
+
 ```


### PR DESCRIPTION
Inputs 示例代码在不添加编译条件的时候，编译到webGL以外的平台会报错
