### PR TITLE
fix: More than two touches at once disorder some 3rd-party packages

### DIFF
--- a/Demo/API/Assets/WX-WASM-SDK-V2/Runtime/wechat-default/weapp-adapter.js
+++ b/Demo/API/Assets/WX-WASM-SDK-V2/Runtime/wechat-default/weapp-adapter.js
@@ -1180,6 +1180,20 @@ const isWK = false;
                 touchEvent.targetTouches = Array.prototype.slice.call(event.touches).map(v => formatTouchEvent(v));
                 touchEvent.changedTouches = event.changedTouches.map(v => formatTouchEvent(v));
                 touchEvent.timeStamp = event.timeStamp;
+                
+                // 如果是cancel，则先end所有touch
+                if(type==="touchcancel"){
+                    const evt = new TouchEvent("touchend");
+                    evt.touches = [];
+                    evt.targetTouches = [];
+                    evt.changedTouches = Array.prototype.concat(touchEvent.changedTouches,touchEvent.touches);
+                    evt.timeStamp = event.timeStamp;
+                    _document2.default.dispatchEvent(evt);
+
+                    touchEvent.touches = 
+                    touchEvent.targetTouches = 
+                    touchEvent.changedTouches = [];
+                }
                 _document2.default.dispatchEvent(touchEvent);
             };
         }


### PR DESCRIPTION
## 问题描述

UIToolkit（可能包括其他第三方库）使用三指及以上触碰后，事件系统变得错乱。表现为：无法再响应滑动事件等。

|基本信息||
|:-|:-|
|频率|必现|
|Platform| WebGL (Minigame)|
|OS| Android|

## 问题分析

多指（>2）操作时，最后的eventType为`touchcancel`，并且`changedTouches`中未包含全部touch，导致C#层识别不到触碰点消失。

## 解决方案

此PR的方法是：cancel事件dispatch之前，先dispatch所有touch的`touchend`事件